### PR TITLE
Added skipping items in the update list in case it's absent from the package list

### DIFF
--- a/src/Utils/Backend.ts
+++ b/src/Utils/Backend.ts
@@ -363,6 +363,10 @@ export class Backend {
       let idx = rpl.findIndex(rplitem => rplitem.application == uplitem.application && rplitem.branch == uplitem.branch && (('remote' in uplitem && rplitem.origin == uplitem.remote) || !('remote' in uplitem)))
       let pkgAction = ''
       let extraParameters = {}
+      if (idx < 0) {
+        console.debug(`[AutoFlatpaks] Item "${uplitem.application}" not found in the package list - skipping`)
+        continue
+      }
       if (['i', 'u'].includes(uplitem.op)) { pkgAction = 'update'}
       if (uplitem.op == 'r') {
         pkgAction = 'uninstall'


### PR DESCRIPTION
I had this issue once before and while debugging it, I've just skipped the item undefined item and updated it without knowing the root cause. 

I couldn't recreate it for the next 9 months until yesterday and this time I've made sure to not update problematic package before knowing the root cause. 

In this case the culprit was:
```json
  {
    "application": "net.davidotek.pupgui2.Locale",
    "branch": "stable",
    "op": "i",
    "remote": "flathub",
    "download_size": "119 bytes",
    "partial": true
  }
```
which was absent from the `rpl`

Probably the `"partial": true` is the offending part and uplitem could be filterd, but I guess skipping the any offending package is better from the user experience perspective.
